### PR TITLE
fix the issue for gray scale input images

### DIFF
--- a/face_alignment/api.py
+++ b/face_alignment/api.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 from enum import Enum
 from skimage import io
+from skimage import color
 try:
     import urllib.request as request_file
 except BaseException:
@@ -183,6 +184,10 @@ class FaceAlignment:
                 image = input_image
 
             detected_faces = self.detect_faces(image)
+
+            if image.ndim == 2:
+                image = color.gray2rgb(image)
+
             if len(detected_faces) > 0:
                 landmarks = []
                 for i, d in enumerate(detected_faces):


### PR DESCRIPTION
When an input image is in gray scale, current code fails because the code expects the image to be 3D while the gray scale image is 2D.

This pull request is to fix the issue by converting a gray scale image into a RGB image.