### PR TITLE
Minor fixes for compatiliby with PyTorch 4.1 and Python 2.7.

### DIFF
--- a/face_alignment/api.py
+++ b/face_alignment/api.py
@@ -13,6 +13,7 @@ except BaseException:
 from .models import FAN, ResNetDepth
 from .utils import *
 
+
 class LandmarksType(Enum):
     """Enum class defining the type of landmarks to detect.
 
@@ -24,6 +25,7 @@ class LandmarksType(Enum):
     _2D = 1
     _2halfD = 2
     _3D = 3
+
 
 class NetworkSize(Enum):
     # TINY = 1

--- a/face_alignment/detection/sfd/detect.py
+++ b/face_alignment/detection/sfd/detect.py
@@ -31,7 +31,7 @@ def detect(net, img, device):
 
     bboxlist = []
     for i in range(len(olist) // 2):
-        olist[i * 2] = F.softmax(olist[i * 2])
+        olist[i * 2] = F.softmax(olist[i * 2], dim=1)
     olist = [oelem.data.cpu() for oelem in olist]
     for i in range(len(olist) // 2):
         ocls, oreg = olist[i * 2], olist[i * 2 + 1]

--- a/face_alignment/detection/sfd/sfd_detector.py
+++ b/face_alignment/detection/sfd/sfd_detector.py
@@ -16,7 +16,7 @@ from .detect import *
 
 class SFDDetector(FaceDetector):
     def __init__(self, device, path_to_detector=None, verbose=False):
-        super().__init__(device, verbose)
+        super(SFDDetector, self).__init__(device, verbose)
 
         base_path = os.path.join(appdata_dir('face_alignment'), "data")
 

--- a/face_alignment/models.py
+++ b/face_alignment/models.py
@@ -134,7 +134,7 @@ class HourGlass(nn.Module):
         low3 = low2
         low3 = self._modules['b3_' + str(level)](low3)
 
-        up2 = F.upsample(low3, scale_factor=2, mode='nearest')
+        up2 = F.interpolate(low3, scale_factor=2, mode='nearest')
 
         return up1 + up2
 

--- a/face_alignment/utils.py
+++ b/face_alignment/utils.py
@@ -151,9 +151,9 @@ def flip(tensor, is_label=False):
         tensor = torch.from_numpy(tensor)
 
     if is_label:
-        tensor = shuffle_lr(tensor).flip(-1)
+        tensor = shuffle_lr(tensor).flip(tensor.ndimension() - 1)
     else:
-        tensor = tensor.flip(-1)
+        tensor = tensor.flip(tensor.ndimension() - 1)
 
     return tensor
 


### PR DESCRIPTION
- SFDDectector is compatible with Python 2.7 now.
- Switched form Upsample to Interpolate, (it will be deprecated in the next PyTorch)
- Specified the dimension for Softmax.
- Changed the flip function call. 

I checked the previous documentations of flip on PyTorch. It seems like they have never accepted a negative input dimension. I'm not sure which version of PyTorch you were using. Also it seems like the flip dimension is always 3, along w assuming (n x c x h x w), but you might be also calling this function with (c x h x w) when `n=1`. So the safest replacement was to call `flip(tensor.ndimension()-1)`.
By the way, thanks for such a great contribution.