### PR TITLE
added 3D batch processing compatibility, patched bugs

### DIFF
--- a/face_alignment/api.py
+++ b/face_alignment/api.py
@@ -230,8 +230,8 @@ class FaceAlignment:
 
                 out = self.face_alignment_net(inp)[-1].detach()
                 if self.flip_input:
-                    out += flip(self.face_alignment_net(flip(inp)) # patched inp_batch undefined variable error
-                                [-1].detach(), is_label=True)
+                    out += flip(self.face_alignment_net(flip(inp))
+                                [-1].detach(), is_label=True)  # patched inp_batch undefined variable error
                 out = out.cpu()
                 pts, pts_img = get_preds_fromhm(out, center, scale)
 
@@ -253,7 +253,6 @@ class FaceAlignment:
                         (pts_img, depth_pred * (1.0 / (256.0 / (200.0 * scale)))), 1)
                 else:
                     pts, pts_img = pts.view(-1, 68, 2) * 4, pts_img.view(-1, 68, 2)
-                
                 landmark_set.append(pts_img.numpy())
 
             landmark_set = np.concatenate(landmark_set, axis=0)

--- a/face_alignment/api.py
+++ b/face_alignment/api.py
@@ -230,14 +230,14 @@ class FaceAlignment:
 
                 out = self.face_alignment_net(inp)[-1].detach()
                 if self.flip_input:
-                    out += flip(self.face_alignment_net(flip(inp_batch))
+                    out += flip(self.face_alignment_net(flip(inp)) # patched inp_batch undefined variable error
                                 [-1].detach(), is_label=True)
                 out = out.cpu()
                 pts, pts_img = get_preds_fromhm(out, center, scale)
-                pts, pts_img = pts.view(-1, 68, 2) * 4, pts_img.view(-1, 68, 2)
 
-                # TODO: Adding 3D landmark support
+                # Added 3D landmark support
                 if self.landmarks_type == LandmarksType._3D:
+                    pts, pts_img = pts.view(68, 2) * 4, pts_img.view(68, 2)
                     heatmaps = np.zeros((68, 256, 256), dtype=np.float32)
                     for i in range(68):
                         if pts[i, 0] > 0:
@@ -251,7 +251,9 @@ class FaceAlignment:
                         torch.cat((inp, heatmaps), 1)).data.cpu().view(68, 1)
                     pts_img = torch.cat(
                         (pts_img, depth_pred * (1.0 / (256.0 / (200.0 * scale)))), 1)
-
+                else:
+                    pts, pts_img = pts.view(-1, 68, 2) * 4, pts_img.view(-1, 68, 2)
+                
                 landmark_set.append(pts_img.numpy())
 
             landmark_set = np.concatenate(landmark_set, axis=0)

--- a/face_alignment/detection/sfd/detect.py
+++ b/face_alignment/detection/sfd/detect.py
@@ -42,7 +42,7 @@ def batch_detect(net, img_batch, device):
     BB, CC, HH, WW = img_batch.size()
 
     with torch.no_grad():
-        olist = net(img_batch)
+        olist = net(img_batch.float()) # patched uint8_t overflow error
 
     for i in range(len(olist) // 2):
         olist[i * 2] = F.softmax(olist[i * 2], dim=1)

--- a/face_alignment/detection/sfd/detect.py
+++ b/face_alignment/detection/sfd/detect.py
@@ -42,7 +42,7 @@ def batch_detect(net, img_batch, device):
     BB, CC, HH, WW = img_batch.size()
 
     with torch.no_grad():
-        olist = net(img_batch.float()) # patched uint8_t overflow error
+        olist = net(img_batch.float())  # patched uint8_t overflow error
 
     for i in range(len(olist) // 2):
         olist[i * 2] = F.softmax(olist[i * 2], dim=1)


### PR DESCRIPTION
I was working with @imadtoubal on research and we were able to take advantage of the batch processing with BlazeFace and face_alignment for a speedup in processing. @esterivera noticed our batch processing was incompatible with 3D landmarks. I have now made this available. Additionally, if using the SFD face detector, batch processing would have thrown a RuntimeError: "value cannot be converted to type uint8_t without overflow." I have patched this bug. Additionally, if using setting the flip_input argument to True, we had an undefined variable. I made this correction as well. Hope this helps.