### PR TITLE
Fix GPU issue on the blazeface detector.

### DIFF
--- a/face_alignment/detection/blazeface/blazeface_detector.py
+++ b/face_alignment/detection/blazeface/blazeface_detector.py
@@ -37,7 +37,7 @@ class BlazeFaceDetector(FaceDetector):
 
         self.face_detector = BlazeFace()
         self.face_detector.load_state_dict(model_weights)
-        self.face_detector.load_anchors_from_npy(model_anchors)
+        self.face_detector.load_anchors_from_npy(model_anchors, device)
 
         # Optionally change the thresholds:
         self.face_detector.min_score_thresh = 0.5

--- a/face_alignment/detection/blazeface/net_blazeface.py
+++ b/face_alignment/detection/blazeface/net_blazeface.py
@@ -156,16 +156,18 @@ class BlazeFace(nn.Module):
         self.load_state_dict(torch.load(path))
         self.eval()
 
-    def load_anchors(self, path):
+    def load_anchors(self, path, device=None):
+        device = device or self._device()
         self.anchors = torch.tensor(
-            np.load(path), dtype=torch.float32, device=self._device())
+            np.load(path), dtype=torch.float32, device=device)
         assert(self.anchors.ndimension() == 2)
         assert(self.anchors.shape[0] == self.num_anchors)
         assert(self.anchors.shape[1] == 4)
 
-    def load_anchors_from_npy(self, arr):
+    def load_anchors_from_npy(self, arr, device=None):
+        device = device or self._device()
         self.anchors = torch.tensor(
-            arr, dtype=torch.float32, device=self._device())
+            arr, dtype=torch.float32, device=device)
         assert(self.anchors.ndimension() == 2)
         assert(self.anchors.shape[0] == self.num_anchors)
         assert(self.anchors.shape[1] == 4)
@@ -275,7 +277,7 @@ class BlazeFace(nn.Module):
         for i in range(raw_box_tensor.shape[0]):
             boxes = detection_boxes[i, mask[i]]
             scores = detection_scores[i, mask[i]].unsqueeze(dim=-1)
-            output_detections.append(torch.cat((boxes, scores), dim=-1))
+            output_detections.append(torch.cat((boxes, scores), dim=-1).to('cpu'))
 
         return output_detections
 


### PR DESCRIPTION
When using the BlazeFace Detector on a CUDA device, the error
```
face_alignment/detection/blazeface/net_blazeface.py", line 288, in _decode_boxes
    x_center = raw_boxes[..., 0] / self.x_scale * \
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```
would be triggered.

This fixes this issue and allows to use the BlazeFace detector on a cuda device.