### PR TITLE
Use logging, not pring for warning

### DIFF
--- a/face_alignment/api.py
+++ b/face_alignment/api.py
@@ -11,6 +11,7 @@ try:
     import urllib.request as request_file
 except BaseException:
     import urllib as request_file
+import logging
 
 from .models import FAN, ResNetDepth
 from .utils import *
@@ -57,6 +58,7 @@ class FaceAlignment:
         self.flip_input = flip_input
         self.landmarks_type = landmarks_type
         self.verbose = verbose
+        self.logger = logging.getLogger(__name__)
 
         network_size = int(network_size)
 
@@ -140,7 +142,7 @@ class FaceAlignment:
             detected_faces = self.face_detector.detect_from_image(image[..., ::-1].copy())
 
         if len(detected_faces) == 0:
-            print("Warning: No faces were detected.")
+            self.logger.warning("No faces were detected.")
             return None
 
         landmarks = []
@@ -204,7 +206,7 @@ class FaceAlignment:
             detected_faces = self.face_detector.detect_from_batch(image_batch)
 
         if len(detected_faces) == 0:
-            print("Warning: No faces were detected.")
+            self.logger.warning("No faces were detected.")
             return None
 
         landmarks = []

--- a/face_alignment/detection/dlib/dlib_detector.py
+++ b/face_alignment/detection/dlib/dlib_detector.py
@@ -1,6 +1,7 @@
 import os
 import cv2
 import dlib
+import logging
 
 try:
     import urllib.request as request_file
@@ -14,8 +15,8 @@ from ...utils import appdata_dir
 class DlibDetector(FaceDetector):
     def __init__(self, device, path_to_detector=None, verbose=False):
         super().__init__(device, verbose)
-
-        print('Warning: this detector is deprecated. Please use a different one, i.e.: S3FD.')
+        logger = logging.getLogger(__name__)
+        logger.warning('this detector is deprecated. Please use a different one, i.e.: S3FD.')
         base_path = os.path.join(appdata_dir('face_alignment'), "data")
 
         # Initialise the face detector


### PR DESCRIPTION
- Replaced print warning with logger.warning  
BTW, I had many images to detect with dlib, but I couldn't suppress / ignore warning as they come from standard output print function. I didn't change for Error printing. 