### PR TITLE
Fix issue with blazeface when img is square

### DIFF
--- a/face_alignment/detection/blazeface/utils.py
+++ b/face_alignment/detection/blazeface/utils.py
@@ -35,7 +35,10 @@ def image_resize(image, width=None, height=None, inter=cv2.INTER_AREA):
 
 
 def resize_and_crop_image(image, dim):
-    if image.shape[0] > image.shape[1]:
+    if image.shape[0] == image.shape[1]:
+        img = cv2.resize(image, (dim, dim))
+        return img, (0, 0)
+    elif image.shape[0] > image.shape[1]:
         img = image_resize(image, width=dim)
         yshift, xshift = (image.shape[0] - image.shape[1]) // 2, 0
         y_start = (img.shape[0] - img.shape[1]) // 2


### PR DESCRIPTION
I think it's error-prone to center-crop and resize when we only need to do a resize. It somehow messes with the dimensions due to numbers rounding off and rescaled img is of size 128 to 127 instead of a square, which fails the assertion downstream. This could be a issue bigger than the example I presented here though, might need to add a few more test to it to make sure whether it only occurs on square images or the non-square images might also need a fix for rounding-off errors.

Script I ran:
```
import face_alignment
from skimage import io
fa = face_alignment.FaceAlignment(face_alignment.LandmarksType._2D, face_detector='blazeface', device='cpu')
input = io.imread('test.jpeg')
preds = fa.get_landmarks(input)
```

Example image I used: https://images.pexels.com/photos/3042160/pexels-photo-3042160.jpeg

Error I got:

```
Traceback (most recent call last):
  File "fa_test.py", line 5, in <module>
    preds = fa.get_landmarks(input)
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/api.py", line 110, in get_landmarks
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/torch/autograd/grad_mode.py", line 26, in decorate_context
    return func(*args, **kwargs)
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/api.py", line 141, in get_landmarks_from_image
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/detection/blazeface/blazeface_detector.py", line 42, in detect_from_image
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/detection/blazeface/detect.py", line 14, in detect
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/detection/blazeface/net_blazeface.py", line 193, in predict_on_image
  File "/home/doruk/anaconda3/envs/fa/lib/python3.7/site-packages/face_alignment-1.3.4-py3.7.egg/face_alignment/detection/blazeface/net_blazeface.py", line 217, in predict_on_batch
AssertionError
```