### PR TITLE
Adding apple metal support

### DIFF
--- a/face_alignment/detection/core.py
+++ b/face_alignment/detection/core.py
@@ -24,9 +24,9 @@ class FaceDetector(object):
                 logger = logging.getLogger(__name__)
                 logger.warning("Detection running on CPU, this may be potentially slow.")
 
-        if 'cpu' not in device and 'cuda' not in device:
+        if 'cpu' not in device and 'cuda' not in device and 'mps' not in device:
             if verbose:
-                logger.error("Expected values for device are: {cpu, cuda} but got: %s", device)
+                logger.error("Expected values for device are: {cpu, cuda, mps} but got: %s", device)
             raise ValueError
 
     def detect_from_image(self, tensor_or_path):


### PR DESCRIPTION
The latest version of PyTorch support Apple Metal (running on Apple Silicon devices, or Apple Intel devices with AMD GPUs), with the device called 'mps' - https://developer.apple.com/metal/pytorch/

This change allows the device to be set to `mps` rather than limiting to `cpu` and `cuda`.