### PR TITLE
Add Apple M1 GPU Option to Class 'DlibDetector'

### DIFF
--- a/face_alignment/detection/dlib/dlib_detector.py
+++ b/face_alignment/detection/dlib/dlib_detector.py
@@ -13,7 +13,7 @@ class DlibDetector(FaceDetector):
         warnings.warn('Warning: this detector is deprecated. Please use a different one, i.e.: S3FD.')
 
         # Initialise the face detector
-        if 'cuda' in device:
+        if 'cuda' in device or 'mps' in device:
             if path_to_detector is None:
                 path_to_detector = load_file_from_url(
                     "https://www.adrianbulat.com/downloads/dlib/mmod_human_face_detector.dat")
@@ -28,7 +28,7 @@ class DlibDetector(FaceDetector):
 
         detected_faces = self.face_detector(cv2.cvtColor(image, cv2.COLOR_BGR2GRAY))
 
-        if 'cuda' not in self.device:
+        if 'cuda' not in self.device and 'mps' not in self.device:
             detected_faces = [[d.left(), d.top(), d.right(), d.bottom()] for d in detected_faces]
         else:
             detected_faces = [[d.rect.left(), d.rect.top(), d.rect.right(), d.rect.bottom()] for d in detected_faces]


### PR DESCRIPTION
In `face_alignment/detection/dlib/dlib_detector.py`, Apple M1 GPU (device = 'mps') seems to be ignored in the previous version.